### PR TITLE
Use session IDs instead of Flask-Login for counselors

### DIFF
--- a/hyperdome_server/web/share_mode.py
+++ b/hyperdome_server/web/share_mode.py
@@ -80,22 +80,17 @@ class ShareModeWeb(object):
         self.user_class = get_user_class_from_db_and_bcrypt(self.db,
                                                             self.bcrypt)
 
+
+
     def define_routes(self):
 
-        @self.web.app.before_request
-        def before_request():
-            user = load_user(request.headers.get("username", ""))
-            if user and user.is_correct_password(
-                    request.headers.get("password", "")):
-                login_user(user)
-
-        @login_manager.user_loader
         def load_user(username):
             if username in self.therapists_available:
                 return username
             self.db.create_all()
             return self.user_class.query.filter(self.user_class.username
                                                 == username).first()
+
 
         @self.web.app.errorhandler(Exception)
         def unhandled_exception(e):
@@ -181,5 +176,6 @@ class ShareModeWeb(object):
 
         @self.web.app.route("/collect_therapist_messages", methods=['GET'])
         def collect_therapist_messages():
-            therapist_username = current_user.username
-            return self.pending_messages.pop(therapist_username, "")
+            sid = request.form['username']
+            if self.pending_messages[sid]:
+                return self.pending_messages.pop(sid, "")

--- a/hyperdome_server/web/share_mode.py
+++ b/hyperdome_server/web/share_mode.py
@@ -101,7 +101,7 @@ class ShareModeWeb(object):
                                                        e,
                                                        e.__traceback__))
             print(e_str)
-            return e_str
+            return "Exception raised", 500
 
         @self.web.app.route("/request_therapist", methods=['POST'])
         def request_therapist():


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR removes most integration into Flask-Login, as it is more complex than necessary for this stage. counselor logins are currently totally unauthenticated, and the API was changed to consolidate logic for guests and counselors. Eventually authentication via the database and Bcrypt will be re-enabled, but it is unlikely that Flask-Login will be re-enabled due to the complexity of using redirects and ensuring they are adequately secured.

### Checklist

<!-- Put an x inside [ ] to check it -->

<!-- You do not have to check all boxes, only the ones that are true -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
    -working towards multiple fixes, directly fixes #49 
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
