### PR TITLE
Chat e2 ee

### DIFF
--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -37,8 +37,8 @@ class LockBox():
         self._private_key = ec.generate_private_key(ec.SECP521R1(), default_backend())
         self._shared_secret = None
 
-    def get_public_key(self):
-        self._private_key.public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+    def get_public_key(self) -> bytes:
+        return self._private_key.public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
     def make_shared_secret(self, public_key_bytes: bytes):
         public_key = load_pem_public_key(public_key_bytes, default_backend())

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -50,17 +50,17 @@ class LockBox():
     _PRIVATE_FORMAT = serial.PrivateFormat.PKCS8
     _KDF = HKDF(_HASH, 32, salt=None, info=b'hyperdome-message', backend=_BACKEND)
 
-    def encrypt_outgoing_message(self, message: bstr) -> bytes:
+    def encrypt_outgoing_message(self, message: bstr) -> str:
         if isinstance(message, str):
             message = message.encode()
 
         new_base_key = self._KDF.derive(self._send_ratchet_key)
         self._send_ratchet_key = new_base_key[:128]
         ciphertext = Fernet(new_base_key[128:]).encrypt(message)
-        return ciphertext
+        return ciphertext.decode('utf-8')
 
 
-    def decrypt_incoming_message(self, message: bstr) -> bytes:
+    def decrypt_incoming_message(self, message: bstr) -> str:
         if isinstance(message, str):
             message = message.encode()
         if not message:
@@ -69,10 +69,10 @@ class LockBox():
         new_base_key = self._KDF.derive(self._recieve_ratchet_key)
         self._send_ratchet_key = new_base_key[:128]
         plaintext = Fernet(new_base_key[128:]).decrypt(message)
-        return plaintext
+        return plaintext.decode('utf-8')
 
     @property
-    def public_chat_key(self) -> bytes:
+    def public_chat_key(self) -> str:
         """
         return a PEM encoded serialized public key digest
         of a new ephemeral X448 key
@@ -83,10 +83,10 @@ class LockBox():
         self._chat_key = X448PrivateKey.generate()
         pub_key_bytes = self._chat_key.public_key().public_bytes(
             self._ENCODING, self._PUBLIC_FORMAT)
-        return pub_key_bytes
+        return pub_key_bytes.decode('utf-8')
 
     @property
-    def public_signing_key(self) -> bytes:
+    def public_signing_key(self) -> str:
         """
         return a PEM encoded serialized public key digest
         of the ed448 signing key
@@ -94,7 +94,7 @@ class LockBox():
         key = self._signing_key.public_key()
         key_bytes = key.public_bytes(
             self._ENCODING, self._PUBLIC_FORMAT)
-        return key_bytes
+        return key_bytes.decode('utf-8')
 
     def perform_key_exchange(self, public_key_bytes: bstr, chirality: bool):
         """
@@ -120,11 +120,11 @@ class LockBox():
     def make_signing_key(self):
         self._signing_key = Ed448PrivateKey.generate()
 
-    def sign_message(self, message: bstr) -> bytes:
+    def sign_message(self, message: bstr) -> str:
         if isinstance(message, str):
             message = message.encode()
         sig = self._signing_key.sign(message)
-        return sig
+        return sig.decode('utf-8')
 
 
     def save_key(self, identifier, passphrase):

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -48,7 +48,7 @@ class LockBox():
     _BACKEND = default_backend()
     _PUBLIC_FORMAT = serial.PublicFormat.SubjectPublicKeyInfo
     _PRIVATE_FORMAT = serial.PrivateFormat.PKCS8
-    _KDF = HKDF(_HASH, 32, salt=None, info='hyperdome-message', backend=_BACKEND)
+    _KDF = HKDF(_HASH, 32, salt=None, info=b'hyperdome-message', backend=_BACKEND)
 
     def encrypt_outgoing_message(self, message: bstr) -> bytes:
         if isinstance(message, str):

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -65,7 +65,7 @@ class LockBox():
             public_key_bytes = public_key_bytes.encode()
         public_key = serial.load_pem_public_key(public_key_bytes, default_backend())
         shared = self._private_key.exchange(ec.ECDH(), public_key)
-        key_gen = HKDF(algorithm=hashes.SHA3_128(), length=16,
+        key_gen = HKDF(algorithm=hashes.SHA3_256(), length=16,
                        salt=None, info=b'handshake', backend=default_backend())
         # TODO consider customizing symmetric encryption for larger key or authentication
         self._shared_secret = Fernet(key_gen.derive(shared))
@@ -79,6 +79,14 @@ class LockBox():
         if isinstance(message, str):
             message = message.encode()
         return self._shared_secret.decrypt(message).decode('utf-8')
+
+    def sign_message(self, message: bstr) -> bytes:
+        if isinstance(message, str):
+            message = message.encode()
+        sig = self._private_key.sign(
+            message,
+            ec.ECDSA(hashes.SHA3_256()))
+        return sig
 
     def rotate(self):
         """

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -43,7 +43,7 @@ class LockBox():
     def make_shared_secret(self, public_key_bytes: bytes):
         public_key = load_pem_public_key(public_key_bytes, default_backend())
         shared = self._private_key.exchange(ec.ECDH(), public_key)
-        key_gen = HKDF(algorithm=hashes.SHA3_512(), length=32, salt=None, info=b'handshake', backend=default_backend())
+        key_gen = HKDF(algorithm=hashes.SHA3_128(), length=16, salt=None, info=b'handshake', backend=default_backend())
         self._shared_secret = Fernet(key_gen.derive(shared))
 
     def encrypt_message(self, message) -> bytes:

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -45,8 +45,20 @@ class LockBox():
         self._shared_secret = Fernet(key_gen.derive(shared))
 
     def encrypt_message(self, message):
-        return self._shared_secret.encrypt(message)
+        try:
+            message_bytes = message.encode()
+        except AttributeError:
+            message_bytes = message
+        finally:
+            return self._shared_secret.encrypt(message_bytes)
 
     def decrypt_message(self, message):
-        return self._shared_secret.decrypt(message)
+        try:
+            message_bytes = message.encode()
+        except AttributeError:
+            message_bytes = message
+        finally:
+            return self._shared_secret.decrypt(message_bytes).decode('utf-8')
 
+    def rotate(self):
+        self._private_key = ec.generate_private_key(ec.SECP521R1(), default_backend())

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -60,11 +60,6 @@ class LockBox():
         new_base_key = self._RATCHET_KDF().derive(self._send_ratchet_key)
         self._send_ratchet_key = new_base_key[:32]
         fernet_key = base64.urlsafe_b64encode(new_base_key[32:])
-        #
-        # DELETE THIS
-        print(f"{fernet_key=}")
-        # DELETE THIS
-        #
         ciphertext = Fernet(fernet_key).encrypt(message)
         return ciphertext.decode('utf-8')
 
@@ -78,11 +73,6 @@ class LockBox():
         new_base_key = self._RATCHET_KDF().derive(self._recieve_ratchet_key)
         self._recieve_ratchet_key = new_base_key[:32]
         fernet_key = base64.urlsafe_b64encode(new_base_key[32:])
-        #
-        # DELETE THIS
-        print(f"{fernet_key=}")
-        # DELETE THIS
-        #
         plaintext = Fernet(fernet_key).decrypt(message)
         return plaintext.decode('utf-8')
 

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -53,12 +53,23 @@ class LockBox():
         self.rotate()
 
     @property
-    def public_key(self) -> bytes:
+    def public_chat_key(self) -> bytes:
         """
         return a PEM encoded serialized public key digest
-        of the current private key
+        of the current private X25519 chat key
         """
         key = self._chat_key.public_key()
+        key_bytes = key.public_bytes(
+            self._ENCODING, self._PUBLIC_FORMAT)
+        return key_bytes
+
+    @property
+    def public_signing_key(self) -> bytes:
+        """
+        return a PEM encoded serialized public key digest
+        of the current private Ed25519 signing key
+        """
+        key = self._signing_key.public_key()
         key_bytes = key.public_bytes(
             self._ENCODING, self._PUBLIC_FORMAT)
         return key_bytes

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -46,20 +46,18 @@ class LockBox():
         self._shared_secret = Fernet(key_gen.derive(shared))
 
     def encrypt_message(self, message):
-        try:
-            message_bytes = message.encode()
-        except AttributeError:
-            message_bytes = message
-        finally:
-            return self._shared_secret.encrypt(message_bytes)
+        if isinstance(message, str):
+            message = message.encode()
+        elif not isinstance(message, bytes):
+            raise TypeError
+        return self._shared_secret.encrypt(message)
 
     def decrypt_message(self, message):
-        try:
-            message_bytes = message.encode()
-        except AttributeError:
-            message_bytes = message
-        finally:
-            return self._shared_secret.decrypt(message_bytes).decode('utf-8')
+        if isinstance(message, str):
+            message = message.encode()
+        elif not isinstance(message, bytes):
+            raise TypeError
+        return self._shared_secret.decrypt(message).decode('utf-8')
 
     def rotate(self):
         self._private_key = ec.generate_private_key(ec.SECP521R1(), default_backend())

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # considering using pyca/cryptography instead
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.fernet import Fernet
@@ -37,7 +38,7 @@ class LockBox():
         self._shared_secret = None
 
     def get_public_key(self):
-        self._private_key.public_key()
+        self._private_key.public_key(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
     def make_shared_secret(self, public_key):
         shared = self._private_key.exchange(ec.ECDH(), public_key)

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # considering using pyca/cryptography instead
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat, load_pem_public_key
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.fernet import Fernet
@@ -38,21 +38,22 @@ class LockBox():
         self._shared_secret = None
 
     def get_public_key(self):
-        self._private_key.public_key(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+        self._private_key.public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
-    def make_shared_secret(self, public_key):
+    def make_shared_secret(self, public_key_bytes: bytes):
+        public_key = load_pem_public_key(public_key_bytes, default_backend())
         shared = self._private_key.exchange(ec.ECDH(), public_key)
         key_gen = HKDF(algorithm=hashes.SHA3_512(), length=32, salt=None, info=b'handshake', backend=default_backend())
         self._shared_secret = Fernet(key_gen.derive(shared))
 
-    def encrypt_message(self, message):
+    def encrypt_message(self, message) -> bytes:
         if isinstance(message, str):
             message = message.encode()
         elif not isinstance(message, bytes):
             raise TypeError
         return self._shared_secret.encrypt(message)
 
-    def decrypt_message(self, message):
+    def decrypt_message(self, message) -> str:
         if isinstance(message, str):
             message = message.encode()
         elif not isinstance(message, bytes):

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -41,6 +41,7 @@ class LockBox():
         return self._private_key.public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
 
     def make_shared_secret(self, public_key_bytes: bytes):
+        assert isinstance(public_key_bytes, bytes)
         public_key = load_pem_public_key(public_key_bytes, default_backend())
         shared = self._private_key.exchange(ec.ECDH(), public_key)
         key_gen = HKDF(algorithm=hashes.SHA3_128(), length=16, salt=None, info=b'handshake', backend=default_backend())
@@ -49,15 +50,13 @@ class LockBox():
     def encrypt_message(self, message) -> bytes:
         if isinstance(message, str):
             message = message.encode()
-        elif not isinstance(message, bytes):
-            raise TypeError
+        assert isinstance(message, bytes)
         return self._shared_secret.encrypt(message)
 
     def decrypt_message(self, message) -> str:
         if isinstance(message, str):
             message = message.encode()
-        elif not isinstance(message, bytes):
-            raise TypeError
+        assert isinstance(message, bytes)
         return self._shared_secret.decrypt(message).decode('utf-8')
 
     def rotate(self):

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -44,12 +44,12 @@ class LockBox():
     _signing_key = None
     _send_ratchet_key= None
     _recieve_ratchet_key = None
-    _HASH = hashes.SHA3_256()
+    _HASH = hashes.SHA3_512()
     _ENCODING = serial.Encoding.PEM
     _BACKEND = default_backend()
     _PUBLIC_FORMAT = serial.PublicFormat.SubjectPublicKeyInfo
     _PRIVATE_FORMAT = serial.PrivateFormat.PKCS8
-    _KDF = functools.partial(HKDF, _HASH, 32, salt=None, info=b'hyperdome-message', backend=_BACKEND)
+    _KDF = functools.partial(HKDF, _HASH, 64, salt=None, info=b'hyperdome-message', backend=_BACKEND)
 
     def encrypt_outgoing_message(self, message: bstr) -> str:
         if isinstance(message, str):
@@ -70,8 +70,8 @@ class LockBox():
             raise ValueError("message must not be 'None' or empty")
 
         new_base_key = self._KDF().derive(self._recieve_ratchet_key)
-        self._send_ratchet_key = new_base_key[:16]
-        plaintext = Fernet(new_base_key[16:]).decrypt(message)
+        self._send_ratchet_key = new_base_key[:32]
+        plaintext = Fernet(new_base_key[32:]).decrypt(message)
         return plaintext.decode('utf-8')
 
     @property
@@ -112,11 +112,11 @@ class LockBox():
         # TODO consider customizing symmetric encryption for larger key or authentication
         new_chat_key = self._KDF().derive(shared)
         if chirality:
-            send_slice = slice(None, 16)
-            recieve_slice = slice(16, None)
+            send_slice = slice(None, 32)
+            recieve_slice = slice(32, None)
         else:
             send_slice = slice(16, None)
-            recieve_slice = slice(None, 16)
+            recieve_slice = slice(None, 32)
         self._send_ratchet_key = new_chat_key[send_slice]
         self._recieve_ratchet_key = new_chat_key[recieve_slice]
 

--- a/hyperdome_client/encryption.py
+++ b/hyperdome_client/encryption.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+Hyperdome
+
+Copyright (C) 2019 Skyelar Craver <scravers@protonmail.com>
+                   and Steven Pitts <makusu2@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+# considering using pyca/cryptography instead
+import Crypto.Cipher.AES as Sym_enc
+import Crypto.PublicKey.ECC as Asym_enc
+import Crypto.Random as Rand
+
+import cryptography.fernet
+
+class LockBox():
+    """
+    handle key storage, encryption and decryption
+    """
+
+    def __init__(self):
+        self._key = Asym_enc.generate()
+        # TODO hard coded key is for testing ONLY
+        self._partial_secret = b'Lx\x84!PMo\x0c\xc8\x88\xb0\xae\xba\x1f\xb5\x8a'
+        self.chat_encryption = None
+
+    def dec_secret(self, message):
+        if self.chat_encryption == None:
+            return
+
+        return self.chat_encryption.decrypt(message)
+
+    def enc_secret(self, message):
+        if self.chat_encryption == None:
+            return
+
+        return self.chat_encryption.encrypt(message)
+
+    def make_shared_secret(self, incoming_partial):
+        secret = self._partial_secret + incoming_partial
+        self.chat_encryption = Sym_enc.new(secret,Sym_enc.MODE_GCM)
+
+    @property
+    def pubkey(self):
+        return self._key.public_key()
+

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -196,7 +196,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         if not self.is_connected and not self.uid:
             return self.handle_error("not in an active chat")
 
-        enc_message = self.crypt.encrypt_message(message)
+        enc_message = self.crypt.encrypt_outgoing_message(message)
 
         send_message = threads.SendMessageTask(
             self.server, self.session, self.uid, enc_message)
@@ -211,7 +211,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         Update UI with messages retrieved from server.
         """
         sender_name = "counselor" if self.server.is_counselor else "user"
-        message_list = [f'{sender_name}: {self.crypt.decrypt(message)}'
+        message_list = [f'{sender_name}: {self.crypt.decrypt_incoming_message(message)}'
                         for message in messages.split('\n') if message]
         self.chat_window.addItems(message_list)
 

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -294,7 +294,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
                 def counselor_got_guest(guest_key: str):
                     if not guest_key:
                         return
-                    self.crypt.perform_key_exchange(guest_key)
+                    self.crypt.perform_key_exchange(guest_key, self.server.is_counselor)
                     self.poll_guest_key_task = None
                     self.get_messages_task = threads.GetMessagesTask(self.session,
                                                                      self.server,
@@ -312,6 +312,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
                                                                # TODO: there should be a connection status enum for better state understanding
                                                                )
             else:
+                self.crypt.perform_key_exchange(counselor, self.server.is_counselor)
                 self.get_messages_task = threads.GetMessagesTask(self.session,
                                                                  self.server,
                                                                  self.uid)

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -27,6 +27,7 @@ from .settings_dialog import SettingsDialog
 from .widgets import Alert
 from .add_server_dialog import AddServerDialog, Server
 from . import threads
+from . import encryption
 
 import requests
 import traceback
@@ -84,6 +85,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.server: Server = Server()
         self.is_connected: bool = False
         self._session: requests.Session = None
+        self.crypt = encryption.LockBox()
 
         # Load settings, if a custom config was passed in
         self.config = config

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -267,6 +267,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         """
         self.chat_window.clear()
         self.message_text_field.clear()
+        self.crypt.rotate()
         if self.is_connected:
             self.disconnect_chat()
         if (self.server_dropdown.currentIndex() ==

--- a/hyperdome_client/threads.py
+++ b/hyperdome_client/threads.py
@@ -277,7 +277,7 @@ def get_uid(server: Server,
     """
     if server.is_counselor:
         uid = session.post(f"{server.url}/counselor_signin",
-                           data={"username": server.username,
+                           files={"username": server.username,
                                  "password": server.password}).text
     else:
         uid = session.get(

--- a/hyperdome_client/threads.py
+++ b/hyperdome_client/threads.py
@@ -299,7 +299,7 @@ def get_messages(server: Server,
 def start_chat(server: Server,
                session: requests.Session,
                uid: str,
-               pub_key: bytes):
+               pub_key: str):
     if server.is_counselor:
         return session.get(f"{server.url}/counselor_signin",
                            data={"pub_key": pub_key}).text

--- a/hyperdome_client/threads.py
+++ b/hyperdome_client/threads.py
@@ -131,7 +131,8 @@ class StartChatTask(QtCore.QRunnable):
     def __init__(self,
                  server: Server,
                  session: requests.Session,
-                 uid: str):
+                 uid: str,
+                 pub_key: bytes):
         super(StartChatTask, self).__init__()
         self.server = server
         self.session = session
@@ -140,7 +141,7 @@ class StartChatTask(QtCore.QRunnable):
     def run(self):
         try:
             self.signals.success.emit(start_chat(
-                self.server, self.session, self.uid))
+                self.server, self.session, self.uid, self.pub_key))
         except requests.RequestException:
             self.signals.error.emit("Couldn't start a chat session")
 
@@ -278,16 +279,16 @@ def get_messages(server: Server,
 
 def start_chat(server: Server,
                session: requests.Session,
-               uid: str):
+               uid: str,
+               pub_key: bytes):
     if server.is_counselor:
         return session.get(f"{server.url}/counselor_signin",
-                           data={"username": server.username,
-                                 "password": server.password}).text
+                           data={"pub_key": pub_key})
 
     else:
         return session.post(
             f"{server.url}/request_counselor",
-            data={"guest_id": uid}).text
+            data={"guest_id": uid, "pub_key": pub_key}).text
 
 
 COMPATIBLE_SERVERS = ['2.0']

--- a/hyperdome_client/threads.py
+++ b/hyperdome_client/threads.py
@@ -137,6 +137,7 @@ class StartChatTask(QtCore.QRunnable):
         self.server = server
         self.session = session
         self.uid = uid
+        self.pub_key = pub_key
 
     def run(self):
         try:
@@ -301,7 +302,7 @@ def start_chat(server: Server,
                pub_key: bytes):
     if server.is_counselor:
         return session.get(f"{server.url}/counselor_signin",
-                           data={"pub_key": pub_key})
+                           data={"pub_key": pub_key}).text
 
     else:
         return session.post(

--- a/hyperdome_server/web/share_mode.py
+++ b/hyperdome_server/web/share_mode.py
@@ -145,6 +145,7 @@ class ShareModeWeb(object):
         def counselor_signout():
             sid = request.form['user_id']
             self.counselors_available.pop(sid, '')
+            self.counselor_keys.pop(sid, '')
             return "Success"
 
         @self.web.app.route("/counselor_signin")

--- a/hyperdome_server/web/share_mode.py
+++ b/hyperdome_server/web/share_mode.py
@@ -104,7 +104,7 @@ class ShareModeWeb(object):
         @self.web.app.route("/request_counselor", methods=['POST'])
         def request_counselor():
             guest_id = request.form['guest_id']
-            guest_key = request.form['public_key']
+            guest_key = request.form['pub_key']
             counselors = [
                 counselor for counselor, capacity in self.counselors_available.items() if capacity]
             if not counselors:

--- a/hyperdome_server/web/share_mode.py
+++ b/hyperdome_server/web/share_mode.py
@@ -77,6 +77,8 @@ class ShareModeWeb(object):
         self.counselors_available = dict()
         self.active_chat_user_map = dict()
         self.pending_messages = dict()
+        self.guest_keys = dict()
+        self.counselor_keys = dict()
         self.user_class = get_user_class_from_db_and_bcrypt(self.db,
                                                             self.bcrypt)
 
@@ -102,6 +104,7 @@ class ShareModeWeb(object):
         @self.web.app.route("/request_counselor", methods=['POST'])
         def request_counselor():
             guest_id = request.form['guest_id']
+            guest_key = request.form['public_key']
             counselors = [
                 counselor for counselor, capacity in self.counselors_available.items() if capacity]
             if not counselors:
@@ -110,7 +113,15 @@ class ShareModeWeb(object):
             self.counselors_available[chosen_counselor] -= 1
             self.active_chat_user_map[guest_id] = chosen_counselor
             self.active_chat_user_map[chosen_counselor] = guest_id
-            return 'Success'
+            self.guest_keys[chosen_counselor] = guest_key
+            counselor_key = self.counselor_keys.pop(chosen_counselor)
+            return counselor_key
+
+        @self.web.app.route("/poll_connected_guest", methods=['GET'])
+        def poll_connected_guest():
+            counselor_id = request.form['counselor_id']
+            guest_key = self.guest_keys.pop(counselor_id, '')
+            return guest_key
 
         @self.web.app.route("/counseling_complete", methods=['POST'])
         def counseling_complete():
@@ -138,11 +149,13 @@ class ShareModeWeb(object):
 
         @self.web.app.route("/counselor_signin")
         def counselor_signin():
+            counselor_key = request.form['pub_key']
             # TODO authenticate
             # user = load_user(request.form['username'])
             sid = binascii.b2a_hex(os.urandom(15)).decode('utf-8')
             # will use capacity variable for this later
             self.counselors_available[sid] = 1
+            self.counselor_keys[sid] = counselor_key
             return sid
 
         @self.web.app.route("/generate_guest_id")


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds end-to-end encryption of chat messages using a signal-like protocol, utilizing ephemeral X448 key exchanges per chat session, with hash-based key rotation for unique symmetric keys on every message. Symmetric encryption is handled by Fernet, which uses AES 128 CBC with HMACs for strong authenticated encryption of messages.

This PR fixes issue #64 

This PR also introduces methods for producing and signing with Ed448 keys targeted for use in authenticating counselors without passwords sometime in the future.
### Checklist

<!-- Put an x inside [ ] to check it -->

<!-- You do not have to check all boxes, only the ones that are true -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
