### PR TITLE
set list orientation to vertical and disable wrapping

### DIFF
--- a/hyperdome_client/add_server_dialog.py
+++ b/hyperdome_client/add_server_dialog.py
@@ -75,6 +75,7 @@ class AddServerDialog(QtWidgets.QDialog):
         self.counselor_password_input = QtWidgets.QLineEdit()
         self.counselor_password_input.setPlaceholderText("Password:")
         self.counselor_password_input.setFixedWidth(200)
+        self.counselor_password_input.setEchoMode(QtWidgets.QLineEdit.PasswordEchoOnEdit)
         self.counselor_password_input.hide()
 
         self.counselor_credentials = QtWidgets.QHBoxLayout()

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -117,20 +117,19 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.settings_button = QtWidgets.QPushButton()
         self.settings_button.setDefault(False)
         self.settings_button.setFixedWidth(40)
-        self.settings_button.setFixedHeight(50)
         self.settings_button.setIcon(
             QtGui.QIcon(self.common.get_resource_path("images/settings_black_18dp.png"))
         )
         self.settings_button.clicked.connect(self.open_settings)
         self.settings_button.setIcon(QtGui.QIcon.fromTheme("settings"))
 
-        self.message_text_field = QtWidgets.QPlainTextEdit()
-        self.message_text_field.setFixedHeight(50)
+        self.message_text_field = QtWidgets.QLineEdit()
+        self.message_text_field.setAlignment(QtCore.Qt.AlignTop)
+        self.message_text_field.returnPressed.connect(self.send_message)
         self.message_text_field.setPlaceholderText("Enter message:")
 
         self.enter_button = QtWidgets.QPushButton("Send")
         self.enter_button.clicked.connect(self.send_message)
-        self.enter_button.setFixedHeight(50)
 
         self.enter_text = QtWidgets.QHBoxLayout()
         self.enter_text.addWidget(self.message_text_field)
@@ -188,7 +187,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         either counsel or guest.
         """
 
-        message = self.message_text_field.toPlainText()
+        message = self.message_text_field.text()
         self.message_text_field.clear()
 
         if not (self.is_connected or self.uid):

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -116,12 +116,10 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         # chat pane
         self.settings_button = QtWidgets.QPushButton()
         self.settings_button.setDefault(False)
-        self.settings_button.setFixedWidth(40)
         self.settings_button.setIcon(
             QtGui.QIcon(self.common.get_resource_path("images/settings_black_18dp.png"))
         )
         self.settings_button.clicked.connect(self.open_settings)
-        self.settings_button.setIcon(QtGui.QIcon.fromTheme("settings"))
 
         self.message_text_field = QtWidgets.QLineEdit()
         self.message_text_field.setAlignment(QtCore.Qt.AlignTop)

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -138,12 +138,12 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.enter_text.addWidget(self.settings_button)
 
         self.chat_window = QtWidgets.QListWidget()
-        self.chat_window.setWordWrap(True)
-        self.chat_window.setWrapping(True)
-        self.chat_window.setAutoScroll(True)
+        self.chat_window.setFlow(QtWidgets.QListWidget.TopToBottom)
+        self.chat_window.setWrapping(False)
         self.chat_window.setVerticalScrollMode(
             QtWidgets.QAbstractItemView.ScrollPerItem
         )
+        self.chat_window.addItems(self.chat_history)
 
         self.chat_pane = QtWidgets.QVBoxLayout()
         self.chat_pane.addWidget(self.chat_window, stretch=1)

--- a/hyperdome_client/hyperdome_client.py
+++ b/hyperdome_client/hyperdome_client.py
@@ -122,7 +122,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.settings_button.clicked.connect(self.open_settings)
 
         self.message_text_field = QtWidgets.QLineEdit()
-        self.message_text_field.setAlignment(QtCore.Qt.AlignTop)
+        self.message_text_field.setClearButtonEnabled(True)
         self.message_text_field.returnPressed.connect(self.send_message)
         self.message_text_field.setPlaceholderText("Enter message:")
 


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
When the chat window filled previously it would wrap vertically and continue on to scroll rightwards. This has been changed so messages are always one-per-row and the window scrolls vertically as expected.

The message entry field was also changed to allow quickly clearing, and enter button to send.

The password entry in the add-server dialog is now masked after entry.

The settings button now shows the correct icon.

This fixes issues  #43 and #17 

### Checklist

<!-- Put an x inside [ ] to check it -->

<!-- You do not have to check all boxes, only the ones that are true -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
