### PR TITLE
Refactored qt tasks

### DIFF
--- a/hyperdome/client/add_server_dialog.py
+++ b/hyperdome/client/add_server_dialog.py
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from hyperdome.client.api import HyperdomeClientApi
 from PyQt5 import QtCore, QtGui, QtWidgets
 import autologging
 

--- a/hyperdome/client/add_server_dialog.py
+++ b/hyperdome/client/add_server_dialog.py
@@ -40,7 +40,6 @@ class AddServerDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         self.session = parent.session
-        self.worker = parent.worker
 
         self.error_message = QtWidgets.QMessageBox(self)
 

--- a/hyperdome/client/api.py
+++ b/hyperdome/client/api.py
@@ -35,8 +35,8 @@ def handle_requests_errors(fn: typing.Callable):
     for errors which are generic to any requests call
     """
 
-    @autologging.logged
     @functools.wraps(fn)
+    @autologging.logged
     def wrapper(*args, **kwargs):
         try:
             response = fn(*args, **kwargs)

--- a/hyperdome/client/api.py
+++ b/hyperdome/client/api.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+Hyperdome
+
+Copyright (C) 2019 Skyelar Craver <scravers@protonmail.com>
+                   and Steven Pitts <makusu2@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import functools
+import json
+import typing
+
+import autologging
+import requests
+
+from ..common.server import Server
+
+
+def handle_requests_errors(fn: typing.Callable):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            getattr(fn, "_log")
+        except AttributeError:
+            return fn(*args, **kwargs)
+        try:
+            response = fn(*args, **kwargs)
+        except requests.ConnectionError:
+            handle_requests_errors._log.warning("couldn't connect to server")
+            raise
+        except requests.Timeout:
+            handle_requests_errors._log.warning("server timed out during request")
+            raise
+        except requests.HTTPError:
+            raise
+        else:
+            return response
+
+    return wrapper
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def send_message(server: Server, session: requests.Session, uid: str, message: str):
+    """
+    Send message to server provided using session for given user
+    """
+    session.post(
+        f"{server.url}/send_message", data={"message": message, "user_id": uid}
+    )
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def get_uid(server: Server, session: requests.Session):
+    """
+    Ask server for a new UID for a new user session
+    """
+    response = session.get(f"{server.url}/generate_guest_id")
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        get_uid._log.exception(response.text)
+        raise
+    else:
+        return response.text
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def get_messages(server: Server, session: requests.Session, uid: str):
+    """
+    collect new messages waiting on server for active session
+    """
+    response = session.get(
+        f"{server.url}/collect_messages", data={"user_id": uid}
+    ).json()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        pass
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def start_chat(
+    server: Server,
+    session: requests.Session,
+    uid: str,
+    pub_key: str,
+    signature: str = "",
+):
+    if server.is_counselor:
+        return session.post(
+            f"{server.url}/counselor_signin",
+            data={
+                "pub_key": pub_key,
+                "signature": signature,
+                "username": server.username,
+            },
+        ).text
+
+    else:
+        return session.post(
+            f"{server.url}/request_counselor",
+            data={"guest_id": uid, "pub_key": pub_key},
+        ).text
+
+
+COMPATIBLE_SERVERS = ["0.2", "0.2.0", "0.2.1"]
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def probe_server(server: Server, session: requests.Session):
+    info = json.loads(session.get(f"{server.url}/probe").text)
+    if info["name"] != "hyperdome":
+        return "not hyperdome"
+    if info["version"] not in COMPATIBLE_SERVERS:
+        return "bad version"
+    return ""
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def get_guest_pub_key(server: Server, session: requests.Session, uid: str):
+    return session.get(
+        f"{server.url}/poll_connected_guest", data={"counselor_id": uid}
+    ).text
+
+
+@autologging.traced
+@autologging.logged
+@handle_requests_errors
+def signup_counselor(
+    server: Server,
+    session: requests.Session,
+    passcode: str,
+    pub_key: str,
+    signature: str,
+):
+    return session.post(
+        f"{server.url}/counselor_signup",
+        data={
+            "username": server.username,
+            "pub_key": pub_key,
+            "signup_code": passcode,
+            "signature": signature,
+        },
+    ).text

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -26,7 +26,7 @@ import requests
 
 from hyperdome.common.common import Settings
 
-from . import threads
+from . import tasks
 from ..common import strings
 from ..common import encryption
 from ..common.common import resource_path

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -26,7 +26,7 @@ import requests
 
 from hyperdome.common.common import Settings
 
-from . import tasks
+from . import api, tasks
 from ..common import strings
 from ..common import encryption
 from ..common.common import resource_path
@@ -62,13 +62,6 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.qtapp: QtWidgets.QApplication = qtapp
         self.app = app
         self.local_only: bool = local_only
-
-        # setup threadpool and tasks for async
-        self.worker = QtCore.QThreadPool.globalInstance()
-        self.get_messages_task: threads.GetMessagesTask = None
-        self.send_message_task: threads.SendMessageTask = None
-        self.get_uid_task: threads.GetUidTask = None
-        self.poll_guest_key_task: threads.PollForConnectedGuestTask = None
 
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self._timer_callback)
@@ -192,19 +185,21 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.message_text_field.clear()
 
         if not (self.is_connected or self.uid):
-            return self.handle_error("not in an active chat")
+            return self.handle_error(Exception("not in an active chat"))
 
         enc_message = self.crypt.encrypt_outgoing_message(message)
-
-        send_message = threads.SendMessageTask(
-            self.server, self.session, self.uid, enc_message
+        send_message_task = tasks.QtTask(
+            self.client.send_message, self.uid, enc_message
         )
-        send_message.signals.error.connect(self.handle_error)
 
-        self.worker.start(send_message)
+        @tasks.run_after_task(send_message_task, error_handler=self.handle_error)
+        @QtCore.pyqtSlot(object)
+        def message_send_success(_):
+            self.__log.debug("message sent successfully")
+
         self.chat_window.addItem(f"You: {message}")
 
-    @QtCore.pyqtSlot(str)
+    @QtCore.pyqtSlot(object)
     def on_history_added(self, messages: str):
         """
         Update UI with messages retrieved from server.
@@ -222,30 +217,31 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         """
         Ask server for a new UID for a new user session
         """
-
-        @QtCore.pyqtSlot(str)
-        def after_id(uid: str):
-            self.uid = uid
-            self.start_chat_button.setEnabled(True)
-
         if self.timer.isActive():
             self.timer.stop()
-        if not self.server.is_counselor:
-            get_uid_task = threads.GetUidTask(self.server, self.session)
-            get_uid_task.signals.success.connect(after_id, QtCore.Qt.UniqueConnection)
-            get_uid_task.signals.error.connect(self.handle_error)
-            self.worker.start(get_uid_task)
-        else:  # user is a counselor which will get uid later
-            after_id("")  # use same callback without uid
 
-    @QtCore.pyqtSlot(str)
-    def handle_error(self, error: str):
+        if self.server.is_counselor:
+            # user is a counselor which will get uid later
+            self.__log.debug("User is counselor, skipping get_uid")
+            self.start_chat_button.setEnabled(True)
+
+        else:
+
+            @tasks.run_after_task(tasks.QtTask(self.client.get_uid), self.handle_error)
+            @QtCore.pyqtSlot(object)
+            def after_id(uid):
+                self.__log.debug("Guest got uid successfully")
+                self.uid = uid
+                self.start_chat_button.setEnabled(True)
+
+    @QtCore.pyqtSlot(Exception)
+    def handle_error(self, error: Exception):
         """
         take error string and assign it to the created alert window
         changes active window with new text
         and brings to focus if currently in the background.
         """
-        self.error_window.setText(error)
+        self.error_window.setText(str(error))
         if self.error_window.isActiveWindow():
             self.error_window.setFocus()
         else:
@@ -283,88 +279,21 @@ class HyperdomeClient(QtWidgets.QMainWindow):
             add_server_dialog = AddServerDialog(self)
             dialog_error = add_server_dialog.exec_()
             if not dialog_error:
-                server = add_server_dialog.get_server()
-                self.server = server
-                self.servers[server.nick] = self.server
-                self.server_dropdown.insertItem(1, server.nick)
+                self.server = add_server_dialog.get_server()
+                self.client = api.HyperdomeClientApi(self.server, self.session)
+                self.servers[self.server.nick] = self.server
+                self.server_dropdown.insertItem(1, self.server.nick)
                 self.server_dropdown.setCurrentIndex(1)
                 self.save_servers()
         elif self.server_dropdown.currentIndex():
             self.__log.debug("switching server")
             self.server = self.servers[self.server_dropdown.currentText()]
+            self.client = api.HyperdomeClientApi(self.server, self.session)
             self.get_uid()
         else:
             self.__log.debug("switched to 'select a server'")
 
     def start_chat(self):
-        @QtCore.pyqtSlot(str)
-        def after_start(counselor: str):
-            if not self.server.is_counselor and not counselor:
-                self.handle_error("No counselors available.")
-                self.start_chat_button.setEnabled(True)
-                return
-            if self.server.is_counselor:
-                self.uid = counselor
-
-                @QtCore.pyqtSlot(str)
-                def counselor_got_guest(guest_key: str):
-                    if not guest_key:
-                        return
-                    self.crypt.perform_key_exchange(guest_key, self.server.is_counselor)
-                    self.poll_guest_key_task = None
-                    self.get_messages_task = threads.GetMessagesTask(
-                        self.session, self.server, self.uid
-                    )
-                    self.get_messages_task.setAutoDelete(False)
-                    try:
-                        # if no connections exist, which happens on first connection,
-                        # .disconnect() raises a TypeError.
-                        # the disconnect is needed because of setAutoDelete properties,
-                        # which was causing slots to be bound recursively,
-                        # and duplicating callback actions
-                        self.get_messages_task.signals.disconnect()
-                    except TypeError:
-                        pass
-                    self.get_messages_task.signals.success.connect(
-                        self.on_history_added
-                    )
-                    self.get_messages_task.signals.error.connect(
-                        lambda _: self.disconnect_chat()
-                    )
-
-                self.poll_guest_key_task = threads.PollForConnectedGuestTask(
-                    self.session, self.server, self.uid
-                )
-                self.poll_guest_key_task.setAutoDelete(False)
-                self.poll_guest_key_task.signals.success.connect(counselor_got_guest)
-                self.poll_guest_key_task.signals.error.connect(
-                    self.handle_error
-                    # TODO: there should be a connection status enum for better state understanding
-                )
-            else:
-                self.crypt.perform_key_exchange(counselor, self.server.is_counselor)
-                self.get_messages_task = threads.GetMessagesTask(
-                    self.session, self.server, self.uid
-                )
-                self.get_messages_task.setAutoDelete(False)
-                try:
-                    # if no connections exist, which happens on first connection,
-                    # .disconnect() raises a TypeError.
-                    # the disconnect is needed because of setAutoDelete properties,
-                    # which was causing slots to be bound recursively,
-                    # and duplicating callback actions
-                    self.get_messages_task.signals.disconnect()
-                except TypeError:
-                    pass
-                self.get_messages_task.signals.success.connect(self.on_history_added)
-                self.get_messages_task.signals.error.connect(
-                    lambda _: self.disconnect_chat()
-                )
-            self.timer.start()
-            self.start_chat_button.setText("Disconnect")
-            self.start_chat_button.clicked.disconnect()
-            self.start_chat_button.clicked.connect(self.disconnect_chat)
-            self.start_chat_button.setEnabled(True)
 
         self.start_chat_button.setEnabled(False)
         pub_key = self.crypt.public_chat_key
@@ -376,12 +305,64 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         else:
             signature = ""
 
-        start_chat_task = threads.StartChatTask(
-            self.server, self.session, self.uid, pub_key, signature
+        start_chat_task = tasks.QtTask(
+            self.client.start_chat(self.uid, pub_key, signature)
         )
-        start_chat_task.signals.success.connect(after_start)
-        start_chat_task.signals.error.connect(self.handle_error)
-        self.worker.start(start_chat_task)
+
+        @tasks.run_after_task(start_chat_task, self.handle_error)
+        @QtCore.pyqtSlot(object)
+        def after_start(counselor):
+            if not self.server.is_counselor and not counselor:
+                self.__log.info("no counselors logged in to server")
+                self.handle_error(Exception("No counselors available."))
+                self.start_chat_button.setEnabled(True)
+                return
+            if self.server.is_counselor:
+                self.uid = counselor
+                self.__log.info("counselor got uid")
+
+                poll_guest_key_task = tasks.QtTask(
+                    self.client.get_guest_pub_key, self.uid
+                )
+
+                @tasks.run_after_task(poll_guest_key_task, self.handle_error)
+                @QtCore.pyqtSlot(object)
+                def counselor_got_guest(guest_key: str):
+                    if not guest_key:
+                        return
+                    self.__log.info("counselor got assigned to guest")
+                    tasks.stop_interval(self.poll_guest_key_task)
+                    self.crypt.perform_key_exchange(counselor, self.server.is_counselor)
+                    self.get_messages_task = tasks.QtIntervalTask(
+                        self.client.get_messages, self.uid, interval=3500
+                    )
+
+                    run_on_interval = tasks.run_after_task(
+                        self.get_messages_task, lambda _: self.disconnect_chat()
+                    )
+                    run_on_interval(self.on_history_added)
+
+                self.poll_guest_key_task.setAutoDelete(False)
+                self.poll_guest_key_task.signals.success.connect(counselor_got_guest)
+                self.poll_guest_key_task.signals.error.connect(
+                    self.handle_error
+                    # TODO: there should be a connection status enum for better state understanding
+                )
+            else:
+                self.crypt.perform_key_exchange(counselor, self.server.is_counselor)
+                self.get_messages_task = tasks.QtIntervalTask(
+                    self.client.get_messages, self.uid, interval=3500
+                )
+
+                run_on_interval = tasks.run_after_task(
+                    self.get_messages_task, lambda _: self.disconnect_chat()
+                )
+                run_on_interval(self.on_history_added)
+
+            self.start_chat_button.setText("Disconnect")
+            self.start_chat_button.clicked.disconnect()
+            self.start_chat_button.clicked.connect(self.disconnect_chat)
+            self.start_chat_button.setEnabled(True)
 
     def _tor_connection_canceled(self):
         """
@@ -463,16 +444,21 @@ class HyperdomeClient(QtWidgets.QMainWindow):
 
     def disconnect_chat(self):
         self.start_chat_button.setEnabled(False)
-        self.timer.stop()
-        self.worker.clear()
-        if self.get_messages_task is not None:
-            self.worker.tryTake(self.get_messages_task)
-            self.get_messages_task = None
-        self.worker.start(threads.EndChatTask(self.session, self.server, self.uid))
+        if task := getattr(self, "get_messages_task"):
+            tasks.stop_interval(task)
+
+        @tasks.run_after_task(tasks.QtTask(self.client.counseling_complete, self.uid))
+        @QtCore.pyqtSlot(object)
+        def disconnected(_):
+            self.__log.info("counseling completed")
+
         if self.server.is_counselor:
-            self.worker.start(
-                threads.CounselorSignoutTask(self.session, self.server, self.uid)
-            )
+
+            @tasks.run_after_task(tasks.QtTask(self.client.signout_counselor, self.uid))
+            @QtCore.pyqtSlot(object)
+            def signed_out(_):
+                self.__log.info("counselor signed out")
+
         self.start_chat_button.setText("Start Chat")
         self.start_chat_button.clicked.disconnect()
         self.start_chat_button_connection = self.start_chat_button.clicked.connect(

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -68,7 +68,6 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.get_messages_task: threads.GetMessagesTask = None
         self.send_message_task: threads.SendMessageTask = None
         self.get_uid_task: threads.GetUidTask = None
-        self.probe_server_task: threads.ProbeServerTask = None
         self.poll_guest_key_task: threads.PollForConnectedGuestTask = None
 
         self.timer = QtCore.QTimer()

--- a/hyperdome/client/tasks.py
+++ b/hyperdome/client/tasks.py
@@ -18,7 +18,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import functools
 import typing
 
 from PyQt5 import QtCore
@@ -232,7 +231,9 @@ def run_after_task(
             run_after_task._log.debug(f"starting {task} in its own thread")
             task.start()
         else:
-            err_str = f"{task} is not an accepted task type"
+            err_str = (
+                f"{type(task)} is not an accepted task type [QtTask, QtIntervalTask]"
+            )
             run_after_task._log.error(err_str)
             raise TypeError(err_str)
         return fn

--- a/hyperdome/client/tasks.py
+++ b/hyperdome/client/tasks.py
@@ -128,7 +128,7 @@ class QtIntervalTask(QtCore.QThread):
                 # calling thread should log error
                 self.__log.debug("interval loop failed")
             finally:
-                self.wait(self.interval)
+                self.sleep(self.interval)
         else:
             self.__log.debug("interval task exited")
             self.signals.finished.emit()
@@ -223,7 +223,7 @@ def run_after_task(
 
     def register_and_run(fn: QtCore.pyqtSlot):
         task.signals.result.connect(fn)
-        run_after_task._log.debug(f"{fn} set as result callback for {task}")
+        run_after_task._log.debug(f"{fn.__name__} set as result callback for {task}")
         if auto_run and isinstance(task, QtTask):
             run_after_task._log.debug(f"starting {task} on the global threadpool")
             QtCore.QThreadPool.globalInstance().start(task)

--- a/hyperdome/client/tasks.py
+++ b/hyperdome/client/tasks.py
@@ -19,8 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import functools
-from hyperdome.client.hyperdome_client import HyperdomeClient
-import json
 import typing
 
 from PyQt5 import QtCore
@@ -41,7 +39,6 @@ from ..common.onion import (
     TorTooOld,
 )
 from ..common.server import Server
-import enum
 
 
 class QtSignals(QtCore.QObject):
@@ -382,139 +379,3 @@ class PollForConnectedGuestTask(QtCore.QRunnable):
             self.signals.success.emit(self.task())
         except:
             self.signals.error.emit("problem getting guest pubkey")
-
-
-@autologging.traced
-@autologging.logged
-def send_message(server: Server, session: requests.Session, uid: str, message: str):
-    """
-    Send message to server provided using session for given user
-    """
-    session.post(
-        f"{server.url}/send_message", data={"message": message, "user_id": uid}
-    )
-
-
-@autologging.traced
-@autologging.logged
-def get_uid(server: Server, session: requests.Session):
-    """
-    Ask server for a new UID for a new user session
-    """
-    response = session.get(f"{server.url}/generate_guest_id")
-    try:
-        response.raise_for_status()
-    except requests.HTTPError:
-        get_uid._log.exception(response.text)
-        raise
-    else:
-        return response.text
-
-
-@autologging.traced
-def get_messages(server: Server, session: requests.Session, uid: str):
-    """
-    collect new messages waiting on server for active session
-    """
-    response = session.get(
-        f"{server.url}/collect_messages", data={"user_id": uid}
-    ).json()
-    try:
-        response.raise_for_status()
-    except requests.HTTPError:
-        pass
-
-
-def handle_requests_errors(fn: typing.Callable):
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        try:
-            getattr(fn, "_log")
-        except AttributeError:
-            return fn(*args, **kwargs)
-        try:
-            response = fn(*args, **kwargs)
-        except requests.ConnectionError:
-            handle_requests_errors._log.warning("couldn't connect to server")
-            raise
-        except requests.Timeout:
-            handle_requests_errors._log.warning("server timed out during request")
-            raise
-        except requests.HTTPError:
-            raise
-        else:
-            return response
-
-    return wrapper
-
-
-@autologging.traced
-@autologging.logged
-@handle_requests_errors
-def start_chat(
-    server: Server,
-    session: requests.Session,
-    uid: str,
-    pub_key: str,
-    signature: str = "",
-):
-    if server.is_counselor:
-        return session.post(
-            f"{server.url}/counselor_signin",
-            data={
-                "pub_key": pub_key,
-                "signature": signature,
-                "username": server.username,
-            },
-        ).text
-
-    else:
-        return session.post(
-            f"{server.url}/request_counselor",
-            data={"guest_id": uid, "pub_key": pub_key},
-        ).text
-
-
-COMPATIBLE_SERVERS = ["0.2", "0.2.0", "0.2.1"]
-
-
-@autologging.traced
-@autologging.logged
-@handle_requests_errors
-def probe_server(server: Server, session: requests.Session):
-    info = json.loads(session.get(f"{server.url}/probe").text)
-    if info["name"] != "hyperdome":
-        return "not hyperdome"
-    if info["version"] not in COMPATIBLE_SERVERS:
-        return "bad version"
-    return ""
-
-
-@autologging.traced
-@autologging.logged
-@handle_requests_errors
-def get_guest_pub_key(server: Server, session: requests.Session, uid: str):
-    return session.get(
-        f"{server.url}/poll_connected_guest", data={"counselor_id": uid}
-    ).text
-
-
-@autologging.traced
-@autologging.logged
-@handle_requests_errors
-def signup_counselor(
-    server: Server,
-    session: requests.Session,
-    passcode: str,
-    pub_key: str,
-    signature: str,
-):
-    return session.post(
-        f"{server.url}/counselor_signup",
-        data={
-            "username": server.username,
-            "pub_key": pub_key,
-            "signup_code": passcode,
-            "signature": signature,
-        },
-    ).text

--- a/hyperdome/client/tasks.py
+++ b/hyperdome/client/tasks.py
@@ -239,3 +239,11 @@ def run_after_task(
         return fn
 
     return register_and_run
+
+
+def stop_interval(task: QtIntervalTask):
+    class stopper(QtCore.QObject):
+        stop = QtCore.pyqtSignal()
+
+    stopper.stop.connect(task.stop)
+    stopper.stop.emit()

--- a/hyperdome/client/tasks.py
+++ b/hyperdome/client/tasks.py
@@ -118,22 +118,23 @@ class QtIntervalTask(QtCore.QThread):
         self.interval = interval
         self.__log.debug(f"interval task {self} created")
 
-    @QtCore.pyqtSlot()
-    def process(self):
-        try:
-            result = self.fn(*self.args, **self.kwargs)
-            self.signals.result.emit(result)
-            self.__log.debug(f"interval task {self} successful")
-        except Exception as error:
-            self.signals.error.emit(error)
-            # calling thread should log error
-            self.__log.debug(f"interval task {self} failed")
-
     def run(self):
         self.__log.debug(f"interval task {self} started")
+
+        @QtCore.pyqtSlot()
+        def process():
+            try:
+                result = self.fn(*self.args, **self.kwargs)
+                self.signals.result.emit(result)
+                self.__log.debug(f"interval task {self} successful")
+            except Exception as error:
+                self.signals.error.emit(error)
+                # calling thread should log error
+                self.__log.debug(f"interval task {self} failed")
+
         timer = QtCore.QTimer()
         timer.setInterval(self.interval)
-        timer.timeout.connect(self.process)
+        timer.timeout.connect(process)
         timer.start()
         self.exec_()
         self.__log.debug(f"interval task {self} finished")

--- a/hyperdome/client/threads.py
+++ b/hyperdome/client/threads.py
@@ -445,6 +445,7 @@ class PollForConnectedGuestTask(QtCore.QRunnable):
             self.signals.error.emit("problem getting guest pubkey")
 
 
+@autologging.traced
 def send_message(server: Server, session: requests.Session, uid: str, message: str):
     """
     Send message to server provided using session for given user
@@ -454,6 +455,7 @@ def send_message(server: Server, session: requests.Session, uid: str, message: s
     )
 
 
+@autologging.traced
 def get_uid(server: Server, session: requests.Session):
     """
     Ask server for a new UID for a new user session
@@ -461,6 +463,7 @@ def get_uid(server: Server, session: requests.Session):
     return session.get(f"{server.url}/generate_guest_id").text
 
 
+@autologging.traced
 def get_messages(server: Server, session: requests.Session, uid: str):
     """
     collect new messages waiting on server for active session
@@ -468,6 +471,7 @@ def get_messages(server: Server, session: requests.Session, uid: str):
     return session.get(f"{server.url}/collect_messages", data={"user_id": uid}).json()
 
 
+@autologging.traced
 def start_chat(
     server: Server,
     session: requests.Session,
@@ -495,6 +499,7 @@ def start_chat(
 COMPATIBLE_SERVERS = ["0.2", "0.2.0", "0.2.1"]
 
 
+@autologging.traced
 def probe_server(server: Server, session: requests.Session):
     info = json.loads(session.get(f"{server.url}/probe").text)
     if info["name"] != "hyperdome":
@@ -504,12 +509,14 @@ def probe_server(server: Server, session: requests.Session):
     return ""
 
 
+@autologging.traced
 def get_guest_pub_key(server: Server, session: requests.Session, uid: str):
     return session.get(
         f"{server.url}/poll_connected_guest", data={"counselor_id": uid}
     ).text
 
 
+@autologging.traced
 def signup_counselor(
     server: Server,
     session: requests.Session,

--- a/hyperdome/server/web.py
+++ b/hyperdome/server/web.py
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import base64
 import hmac
-import autologging
 from pathlib import Path
 import queue
 import secrets
@@ -28,6 +27,7 @@ import socket
 from time import sleep
 from urllib.request import urlopen
 
+import autologging
 from flask import abort, jsonify, make_response, render_template, request
 
 from . import models
@@ -37,10 +37,12 @@ from .app import app, db
 
 @autologging.traced
 @autologging.logged
-class Web(object):
+class Web:
     """
     The Web object is the hyperdome web server, powered by flask
     """
+
+    __log: autologging.logging.Logger  # makes linter happy about autologging
 
     REQUEST_LOAD = 0
     REQUEST_STARTED = 1


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This is a significant refactor of all code relating qt's concurrency constructs and hyperdome's server interaction API.

All http requests used to interact with the server are now in their own module and are qt agnostic, as well as much more well logged.
This will allow future API changes to be made much more easily, and greatly simplify the construction of alternate clients, such as a CLI or a mobile app version.
This api is also much more well logged than previously, and logging will improve significantly when the server api is revised to make better use of JSON.

The qt threading/task execution code was completely remade to use much more generic constructs with the code injected, like from the api module. These generic tasks are more well-implemented and follow qt design ruled more nicely, and effectively hiding many qt related implementation details.

Also in the threading interface is a high-level function/decorator that drastically simplifies the managing of task callbacks and lifetimes.

Since the new tasks implementation follows qt guidelines more, it means less unexpected behavior and higher stability especially in relation to cancelling tasks and sudden errors.

This pr fixes #60 and #68 

### Checklist

<!-- Put an x inside [ ] to check it -->

<!-- You do not have to check all boxes, only the ones that are true -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
