### PR TITLE
Remove shutdown timer

### DIFF
--- a/hyperdome/common/common.py
+++ b/hyperdome/common/common.py
@@ -285,26 +285,3 @@ class Settings(object):
         self.fill_in_defaults()
         self.save()
 
-
-# TODO #95 Replace with threading.Timer()
-@autologging.traced
-@autologging.logged
-class ShutdownTimer(threading.Thread):
-    """
-    Background thread sleeps t hours and returns.
-    """
-
-    __log: autologging.logging.Logger  # to help linters that don't recognize autologging
-
-    def __init__(self, time):
-        threading.Thread.__init__(self)
-
-        self.__log.debug("__init__")
-
-        self.setDaemon(True)
-        self.time = time
-
-    def run(self):
-        self.__log.info(f"Server will shut down after {self.time} seconds")
-        time.sleep(self.time)
-        return 1

--- a/hyperdome/common/common.py
+++ b/hyperdome/common/common.py
@@ -27,8 +27,6 @@ import platform
 import secrets
 import socket
 import sys
-import threading
-import time
 import typing
 
 import autologging

--- a/hyperdome/server/hyperdome_server.py
+++ b/hyperdome/server/hyperdome_server.py
@@ -24,7 +24,7 @@ import shutil
 
 import autologging
 
-from ..common.common import ShutdownTimer, get_available_port
+from ..common.common import get_available_port
 
 
 @autologging.traced
@@ -37,7 +37,7 @@ class HyperdomeServer(object):
 
     __log: autologging.logging.Logger  # stop linter errors from autologging
 
-    def __init__(self, onion, local_only=False, shutdown_timeout=0):
+    def __init__(self, onion, local_only=False):
 
         # The Onion object
         self.onion = onion
@@ -54,11 +54,6 @@ class HyperdomeServer(object):
         # do not use tor -- for development
         self.local_only = local_only
 
-        # optionally shut down after N hours
-        self.shutdown_timeout = shutdown_timeout
-        # init timing thread
-        self.shutdown_timer = None
-
     @property
     def port(self):
         """
@@ -73,9 +68,6 @@ class HyperdomeServer(object):
         """
         Start the hyperdome onion service.
         """
-
-        if self.shutdown_timeout > 0:
-            self.shutdown_timer = ShutdownTimer(self.shutdown_timeout)
 
         if self.local_only:
             self.onion_host = f"127.0.0.1:{self.port:d}"

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -83,13 +83,10 @@ def main(cwd="", shutdown_timeout=0):
     t.daemon = True
     t.start()
 
-    def timeout(event: threading.Event):
-        event.set()
-
     timeout_event = threading.Event()
     shutdown_timer = threading.Timer(
         shutdown_timeout,
-        timeout if shutdown_timeout else lambda _: None,
+        lambda event: (event.set() if shutdown_timeout else None),
         [timeout_event],
     )
 

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -96,12 +96,11 @@ def main(cwd="", shutdown_timeout=0):
         )
         shutdown_timer.start()
 
-        print("")
-        url = f"http://{app.onion_host}"
-        print(strings._("give_this_url"))
-        print(url)
-        print()
-        print(strings._("ctrlc_to_stop"))
+        print(
+            f"{strings._('give_this_url')}\n"
+            f"http://{app.onion_host}\n"
+            f"{strings._('ctrlc_to_stop')}"
+        )
 
         while t.is_alive():
             time.sleep(1)

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -88,14 +88,13 @@ def main(cwd="", shutdown_timeout=0):
         # Wait for web.generate_slug() to finish running
         time.sleep(0.2)
 
-        # start shutdown timer thread
-        if shutdown_timeout:
+        def timeout():
+            raise TimeoutError("timer expired, server shutting down.")
 
-            def timeout():
-                raise TimeoutError("timer expired, server shutting down.")
-
-            t = threading.Timer(shutdown_timeout, timeout)
-            t.start()
+        shutdown_timer = threading.Timer(
+            shutdown_timeout, timeout if shutdown_timeout else lambda: None
+        )
+        shutdown_timer.start()
 
         print("")
         url = f"http://{app.onion_host}"

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -34,7 +34,7 @@ from .web import Web
 
 @autologging.traced
 @autologging.logged
-def main(cwd="", shutdown_timeout=0):
+def main(cwd=""):
     """
     The main() function implements all of the logic that the command-line
     version of hyperdome uses.
@@ -83,13 +83,6 @@ def main(cwd="", shutdown_timeout=0):
     t.daemon = True
     t.start()
 
-    timeout_event = threading.Event()
-    shutdown_timer = threading.Timer(
-        shutdown_timeout,
-        lambda event: (event.set() if shutdown_timeout else None),
-        [timeout_event],
-    )
-
     try:  # Trap Ctrl-C
         # TODO this looks dangerously like a race condition
         # Wait for web.generate_slug() to finish running
@@ -101,12 +94,8 @@ def main(cwd="", shutdown_timeout=0):
             f"{strings._('ctrlc_to_stop')}"
         )
 
-        shutdown_timer.start()
-
         while t.is_alive():
             time.sleep(1)
-            if timeout_event.is_set():
-                raise TimeoutError()
 
     except KeyboardInterrupt:
         main._log.info("application stopped from keyboard interrupt")

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -34,7 +34,7 @@ from .web import Web
 
 @autologging.traced
 @autologging.logged
-def main(cwd=""):
+def main(cwd="", shutdown_timeout=0):
     """
     The main() function implements all of the logic that the command-line
     version of hyperdome uses.
@@ -69,7 +69,7 @@ def main(cwd=""):
 
     # Start the hyperdome server
     try:
-        app = HyperdomeServer(onion, False, 0)
+        app = HyperdomeServer(onion, False)
         app.start_onion_service()
     except KeyboardInterrupt:
         main._log.info("keyboard interrupt during onion setup, exiting")
@@ -89,8 +89,13 @@ def main(cwd=""):
         time.sleep(0.2)
 
         # start shutdown timer thread
-        if app.shutdown_timeout > 0:
-            app.shutdown_timer.start()
+        if shutdown_timeout:
+
+            def timeout():
+                raise TimeoutError("timer expired, server shutting down.")
+
+            t = threading.Timer(shutdown_timeout, timeout)
+            t.start()
 
         print("")
         url = f"http://{app.onion_host}"
@@ -99,20 +104,14 @@ def main(cwd=""):
         print()
         print(strings._("ctrlc_to_stop"))
 
-        # Wait for app to close
         while t.is_alive():
-            if app.shutdown_timeout > 0:
-                # if the shutdown timer was set and has run out, stop the
-                # server
-                if not app.shutdown_timer.is_alive():
-                    pass
-                    # TODO if hyperdome session is over, break. Or just add
-                    # to the conditions with app.shutdown_timer.is_alive().
-            # Allow KeyboardInterrupt exception to be handled with threads
-            # https://stackoverflow.com/questions/3788208
-            time.sleep(0.2)
+            time.sleep(1)
+
     except KeyboardInterrupt:
         main._log.info("application stopped from keyboard interrupt")
+        web.stop(app.port)
+    except TimeoutError:
+        main._log.info("application stopped from timer expiration")
         web.stop(app.port)
     finally:
         main._log.debug("shutdown")

--- a/hyperdome/server/scripts/cli.py
+++ b/hyperdome/server/scripts/cli.py
@@ -47,8 +47,15 @@ logging.addLevelName(1000, "OFF")
     help="file to to write logs to for this run instead of stdout",
     default=None,
 )
+@click.option(
+    "--timeout",
+    type=click.FloatRange(0,),
+    help="shutdown the server after n seconds, 0 for no timeout",
+    default=0,
+    show_default=True,
+)
 @click.pass_context
-def admin(ctx, log_level, log_file):
+def admin(ctx, log_level, log_file, timeout):
     if log_level != "TRACE":
         install_traced_noop()
 
@@ -67,7 +74,7 @@ def admin(ctx, log_level, log_file):
 
         click.echo(f"Hyperdome Server {version} | https://hyperdome.org")
 
-        main()
+        main(shutdown_timeout=timeout)
 
 
 @admin.command()

--- a/hyperdome/server/scripts/cli.py
+++ b/hyperdome/server/scripts/cli.py
@@ -47,15 +47,8 @@ logging.addLevelName(1000, "OFF")
     help="file to to write logs to for this run instead of stdout",
     default=None,
 )
-@click.option(
-    "--timeout",
-    type=click.FloatRange(0,),
-    help="shutdown the server after n seconds, 0 for no timeout",
-    default=0,
-    show_default=True,
-)
 @click.pass_context
-def admin(ctx, log_level, log_file, timeout):
+def admin(ctx, log_level, log_file):
     if log_level != "TRACE":
         install_traced_noop()
 
@@ -74,7 +67,7 @@ def admin(ctx, log_level, log_file, timeout):
 
         click.echo(f"Hyperdome Server {version} | https://hyperdome.org")
 
-        main(shutdown_timeout=timeout)
+        main()
 
 
 @admin.command()


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
While creating unit tests it was observed that the ShutdownTimer class in the common module was duplicating the native functionality of threading.Timer, and may introduce unecessary bugs.

Initially, the plan was to replace the ShutdownTimer implementation with the native timer. However after completing the change, it became unclear if the functionality provided by the shutdown timer is a useful feature for the hyperdome server where it was used. Thus the functionality was removed.

If in the future this functionality is required again, a new PR will be created to implement the functionality.

This PR closes #95 
### Checklist

<!-- Put an x inside [ ] to check it -->

<!-- You do not have to check all boxes, only the ones that are true -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
