### PR TITLE
Threading clean exit

### DIFF
--- a/hyperdome/client/add_server_dialog.py
+++ b/hyperdome/client/add_server_dialog.py
@@ -35,7 +35,7 @@ class AddServerDialog(QtWidgets.QDialog):
     """
 
     def __init__(self, parent: QtCore.QObject):
-        super(AddServerDialog, self).__init__(parent)
+        super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         self.session = parent.session

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -55,7 +55,7 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         config: str = "",
         local_only: bool = False,
     ):
-        super(HyperdomeClient, self).__init__()
+        super().__init__()
 
         # set application variables
         self.settings = settings

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -242,8 +242,13 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         changes active window with new text
         and brings to focus if currently in the background.
         """
-        self.error_window.setText(error.args[0] or "no error description provided")
-        self.__log.debug(f'Received "{type(error)}" from task')
+        self.error_window.setText(
+            error.args[0]
+            if isinstance(error.args[0], str)
+            else "no error description provided"
+        )
+        self.__log.debug(f"Received error from task, set logging to TRACE for info")
+        self.__log.log(0, "exception details:", exc_info=True)
         if self.error_window.isActiveWindow():
             self.error_window.setFocus()
         else:

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -501,8 +501,6 @@ class HyperdomeClient(QtWidgets.QMainWindow):
 
         if self.onion:
             self.onion.cleanup()
-        if self.app:
-            self.app.cleanup()
 
         super().closeEvent(event)
         self.__log.info("hyperdome client closed")

--- a/hyperdome/client/hyperdome_client.py
+++ b/hyperdome/client/hyperdome_client.py
@@ -50,8 +50,6 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         settings,
         onion,
         qtapp: QtWidgets.QApplication,
-        app,
-        filenames,
         config: str = "",
         local_only: bool = False,
     ):
@@ -61,7 +59,6 @@ class HyperdomeClient(QtWidgets.QMainWindow):
         self.settings = settings
         self.onion = onion
         self.qtapp: QtWidgets.QApplication = qtapp
-        self.app = app
         self.local_only: bool = local_only
 
         # setup interval task attributes

--- a/hyperdome/client/main.py
+++ b/hyperdome/client/main.py
@@ -28,7 +28,6 @@ import stem
 from ..common import strings
 from ..common.common import Settings, platform_str
 from ..common.onion import Onion
-from ..server.hyperdome_server import HyperdomeServer
 from .hyperdome_client import HyperdomeClient
 
 
@@ -84,11 +83,8 @@ def main():
     # Start the Onion
     onion = Onion(settings)
 
-    # Start the hyperdome app
-    app = HyperdomeServer(onion)
-
     # Launch the gui
-    main_window = HyperdomeClient(settings, onion, qtapp, app, None)
+    main_window = HyperdomeClient(settings, onion, qtapp)
     main_window.show()
 
     # Clean up when app quits
@@ -99,7 +95,6 @@ def main():
             onion.cleanup()
         except stem.SocketClosed:
             pass
-        app.cleanup()
 
     # All done
     sys.exit(qtapp.exec_())

--- a/hyperdome/client/settings_dialog.py
+++ b/hyperdome/client/settings_dialog.py
@@ -61,7 +61,7 @@ class SettingsDialog(QtWidgets.QDialog):
         config_file: str = "",
         local_only: bool = False,
     ):
-        super(SettingsDialog, self).__init__()
+        super().__init__()
 
         self.settings = settings
 

--- a/hyperdome/client/tasks.py
+++ b/hyperdome/client/tasks.py
@@ -158,7 +158,7 @@ class OnionThread(QtCore.QThread):
     error = QtCore.pyqtSignal(str)
 
     def __init__(self, mode):
-        super(OnionThread, self).__init__()
+        super().__init__()
         self.mode = mode
         self.__log.debug("__init__")
 

--- a/hyperdome/client/tor_connection_dialog.py
+++ b/hyperdome/client/tor_connection_dialog.py
@@ -38,7 +38,7 @@ class TorConnectionDialog(QtWidgets.QProgressDialog):
     open_settings = QtCore.pyqtSignal()
 
     def __init__(self, settings, qtapp, onion, custom_settings=False):
-        super(TorConnectionDialog, self).__init__(None)
+        super().__init__(None)
 
         self.settings = custom_settings or settings
 
@@ -127,7 +127,7 @@ class TorConnectionThread(QtCore.QThread):
     error_connecting_to_tor = QtCore.pyqtSignal(str)
 
     def __init__(self, settings, dialog, onion):
-        super(TorConnectionThread, self).__init__()
+        super().__init__()
 
         self.settings = settings
 

--- a/hyperdome/client/widgets.py
+++ b/hyperdome/client/widgets.py
@@ -38,7 +38,7 @@ class Alert(QtWidgets.QMessageBox):
         buttons=QtWidgets.QMessageBox.Ok,
         autostart=True,
     ):
-        super(Alert, self).__init__(None)
+        super().__init__(None)
 
         self.setWindowTitle("hyperdome")
         self.setWindowIcon(

--- a/hyperdome/common/common.py
+++ b/hyperdome/common/common.py
@@ -105,6 +105,16 @@ def tor_paths() -> typing.Tuple[Path, Path, Path, Path]:
     )
 
 
+@bootstrap
+def host() -> str:
+    # In Whonix, listen on 0.0.0.0 instead of 127.0.0.1 (onionshare #220)
+    return (
+        "0.0.0.0"
+        if Path("/usr/share/anon-ws-base-files/workstation").exists()
+        else "127.0.0.1"
+    )
+
+
 MAX_PORT = 65535
 MIN_PORT = 0
 MAX_PORT_RETRY = 100

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import time
 import autologging
 import os
 import sys

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -83,20 +83,17 @@ def main(cwd=""):
         sys.exit()
 
     # Start hyperdome http service in new thread
-    web_starting = threading.Condition(threading.Lock())
-    t = threading.Thread(target=web.start, args=(app.port, web_starting, True))
+    t = threading.Thread(target=web.start, args=(app.port, True))
     t.daemon = True
     t.start()
 
     try:  # Trap exit conditions for cleanup
-        # Wait for web setup to finish running
-        web_starting.wait(10)
-        main._log.debug("web object started and released lock")
-
+        while not web.running:
+            t.join(0.1)
         print(
-            f"{strings._('give_this_url')}\n"
+            f"\n{strings._('give_this_url')}\n"
             f"http://{app.onion_host}\n"
-            f"{strings._('ctrlc_to_stop')}"
+            f"{strings._('ctrlc_to_stop')}\n"
         )
 
         while t.is_alive():

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -88,6 +88,7 @@ def main(cwd=""):
         # Wait for web setup to finish running
         while web_starting.locked():
             time.sleep(0.1)
+        main._log.debug("web object started and released lock")
 
         print(
             f"{strings._('give_this_url')}\n"

--- a/hyperdome/server/main.py
+++ b/hyperdome/server/main.py
@@ -64,7 +64,6 @@ def main(cwd=""):
         main._log.info("keyboard interrupt during onion setup")
         sys.exit()
     except Exception as e:
-        main._log.exception()
         sys.exit(e.args[0])
 
     # Start the hyperdome server

--- a/hyperdome/server/web.py
+++ b/hyperdome/server/web.py
@@ -26,6 +26,7 @@ import secrets
 import socket
 from time import sleep
 from urllib.request import urlopen
+import threading
 
 import autologging
 from flask import abort, jsonify, make_response, render_template, request
@@ -334,10 +335,11 @@ class Web:
         func()
         self.running = False
 
-    def start(self, port, stay_open=False):
+    def start(self, port, start_flag: threading.Lock, stay_open=False):
         """
         Start the flask web server.
         """
+        start_flag.acquire(blocking=True)
 
         self.stay_open = stay_open
 
@@ -359,6 +361,7 @@ class Web:
 
         self.running = True
         app.run(host=host, port=port, threaded=True)
+        start_flag.release()
 
     def stop(self, port):
         """
@@ -385,4 +388,3 @@ class Web:
                     ).read()
                 except TypeError:
                     self.__log.warning("shutdown url failed", exc_info=True)
-                    pass

--- a/hyperdome/server/web.py
+++ b/hyperdome/server/web.py
@@ -335,30 +335,13 @@ class Web:
         func()
         self.running = False
 
-    def start(self, port, stay_open=False):
+    def start(self, host: str, port: int, stay_open: bool = False):
         """
         Start the flask web server.
         """
         self.stay_open = stay_open
-
-        # Make sure the stop_q is empty when starting a new server
-        while not self.stop_q.empty():
-            try:
-                self.stop_q.get(block=False)
-                self.__log.debug("startup waiting for queue to be empty...")
-                sleep(0.1)
-            except queue.Empty:
-                pass
-
-        # In Whonix, listen on 0.0.0.0 instead of 127.0.0.1 (onionshare #220)
-        host = (
-            "0.0.0.0"
-            if Path("/usr/share/anon-ws-base-files/workstation").exists()
-            else "127.0.0.1"
-        )
-
-        self.running = True
         app.run(host=host, port=port, threaded=True)
+        self.running = True
 
     def stop(self, port):
         """
@@ -385,3 +368,14 @@ class Web:
                     ).read()
                 except TypeError:
                     self.__log.warning("shutdown url failed", exc_info=True)
+
+
+def check_stop(web: Web):
+    # Make sure the stop_q is empty when starting a new server
+    while not web.stop_q.empty():
+        try:
+            web.stop_q.get(block=False)
+            web.__log.debug("startup waiting for queue to be empty...")
+            sleep(0.1)
+        except queue.Empty:
+            pass

--- a/hyperdome/server/web.py
+++ b/hyperdome/server/web.py
@@ -335,12 +335,10 @@ class Web:
         func()
         self.running = False
 
-    def start(self, port, start_flag: threading.Condition, stay_open=False):
+    def start(self, port, stay_open=False):
         """
         Start the flask web server.
         """
-        start_flag.acquire()
-
         self.stay_open = stay_open
 
         # Make sure the stop_q is empty when starting a new server
@@ -361,8 +359,6 @@ class Web:
 
         self.running = True
         app.run(host=host, port=port, threaded=True)
-        start_flag.notify_all()
-        start_flag.release()
 
     def stop(self, port):
         """

--- a/hyperdome/server/web.py
+++ b/hyperdome/server/web.py
@@ -335,11 +335,11 @@ class Web:
         func()
         self.running = False
 
-    def start(self, port, start_flag: threading.Lock, stay_open=False):
+    def start(self, port, start_flag: threading.Condition, stay_open=False):
         """
         Start the flask web server.
         """
-        start_flag.acquire(blocking=True)
+        start_flag.acquire()
 
         self.stay_open = stay_open
 
@@ -352,7 +352,7 @@ class Web:
             except queue.Empty:
                 pass
 
-        # In Whonix, listen on 0.0.0.0 instead of 127.0.0.1 (#220)
+        # In Whonix, listen on 0.0.0.0 instead of 127.0.0.1 (onionshare #220)
         host = (
             "0.0.0.0"
             if Path("/usr/share/anon-ws-base-files/workstation").exists()
@@ -361,6 +361,7 @@ class Web:
 
         self.running = True
         app.run(host=host, port=port, threaded=True)
+        start_flag.notify_all()
         start_flag.release()
 
     def stop(self, port):


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR reworks app initialization and main functions to be more resilient to errors.

The server initialization was refactored slightly to remove a magic wait, by moving some initialization to main thread with results injected into the thread before daemonizing. 

The client was inadvertently spawning the entire flask application and holding a reference to it through its life cycle. This occasionally was a cause for odd error messages during startup and shutdown because the client was holding sockets and resources that conflicted with the server. This PR removes this initialization completely from the client such that it is totally decoupled, and there is no longer any resource contention.

This closes #87 

### Checklist

<!-- Put an x inside [ ] to check it -->

<!-- You do not have to check all boxes, only the ones that are true -->

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
server and client main entrypoints had arguments changed. This should only affect the respective main functions which call the entrypoints.
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
